### PR TITLE
Add enumerate notification template ids

### DIFF
--- a/Public/Set-CUCNotificationHTMLDevice.ps1
+++ b/Public/Set-CUCNotificationHTMLDevice.ps1
@@ -20,6 +20,9 @@ Set-CUCNotificationHTMLDevice -alias demo@demo.com -DisplayName "HTML Missed Cal
 		
         [Parameter(Mandatory = $true, ValueFromPipeline = $True)]
         [bool]$Enabled,
+	
+	[Parameter(Mandatory = $false, ValueFromPipeline = $True)]
+	[string]$NotificationTemplate,
 		
         [Parameter(Mandatory = $false, HelpMessage = 'Cisco Unity Session')]
         $session = $DefaultCUCSession

--- a/Public/Set-CUCNotificationHTMLDevice.ps1
+++ b/Public/Set-CUCNotificationHTMLDevice.ps1
@@ -9,6 +9,8 @@ Set Cisco Unity Users' HTML Notifcation Device
 .EXAMPLE
 Set-CUCNotificationHTMLDevice -alias demo@demo.com -DisplayName "HTML Missed Call" -Enabled $true
 
+.EXAMPLE
+Set-CUCNotificationHTMLDevice -alias demo@demo.com -DisplayName "HTML Scheduled Summary" -Enabled $true -NotificationTemplateName "Default_Missed_Call_With_Summary"
 #>
     [CmdletBinding()]
     Param (
@@ -22,7 +24,7 @@ Set-CUCNotificationHTMLDevice -alias demo@demo.com -DisplayName "HTML Missed Cal
         [bool]$Enabled,
 	
 	[Parameter(Mandatory = $false, ValueFromPipeline = $True)]
-	[string]$NotificationTemplate,
+	[string]$NotificationTemplateName,
 		
         [Parameter(Mandatory = $false, HelpMessage = 'Cisco Unity Session')]
         $session = $DefaultCUCSession
@@ -45,17 +47,22 @@ Set-CUCNotificationHTMLDevice -alias demo@demo.com -DisplayName "HTML Missed Cal
         $NotificationDevice = $NotificationDevices | ? {$_.displayname -eq $DisplayName}
 		
         $URI = "https://$($session['server'])$($NotificationDevice.URI)"
-		
-        # if config NotificationID missing use Default_Missed_Call HTML Template
-        # else use custom HTML Template
-        # TODO: enumerate HTML Template ObjectIDs, don't rely on static objectid
-        if (-not $config.NotificationTemplateID) { $NotificationTemplateID = "a4cf3357-3856-48d5-a75e-8848a673fa66" }
-        else { $NotificationTemplateID = $config.NotificationTemplateID }
+				
+	# if NotificationTemplateName missing use Default_Missed_Call HTML Template
+	# else use custom HTML Template
+        if (-not $NotificationTemplateName) {
+		Write-Verbose -Message "[$($MyInvocation.MyCommand)] Getting Notification Template: Default_Missed_Call"
+		$NotificationTemplate = Get-CUCNotificationTemplate "Default_Missed_Call" 
+	}
+        else { 
+		Write-Verbose -Message "[$($MyInvocation.MyCommand)] Getting Custom Notification Template: $NotificationTemplateName"
+		$NotificationTemplate = Get-CUCNotificationTemplate $NotificationTemplateName
+	}
 		
         $json = [ordered]@{
             SmtpAddress            = $user.user.EmailAddress
             Active                 = $Enabled
-            NotificationTemplateID = $NotificationTemplateID
+            NotificationTemplateID = $NotificationTemplate.NotificationTemplateID
         }
 		
         $body = $json | ConvertTo-Json
@@ -68,11 +75,12 @@ Set-CUCNotificationHTMLDevice -alias demo@demo.com -DisplayName "HTML Missed Cal
             ContentType = 'application/json'
         }
 		
-        try { 
-            $request = invoke-restmethod @irmSplat -ErrorVariable apiErr
+        try {
+		Write-Verbose -Message "[$($MyInvocation.MyCommand)] Setting alias: $alias, notification: $($NotificationDevice.DisplayName) to $Enabled with template: $($NotificationTemplate.NotificationTemplateName)"		
+		$request = invoke-restmethod @irmSplat -ErrorVariable apiErr
         } 
         catch {
-            write-warning $apiErr.InnerException
+		write-warning $apiErr.InnerException
         }
     }
 }

--- a/en-US/config.psd1
+++ b/en-US/config.psd1
@@ -15,7 +15,4 @@ templatealias   = voicemailusertemplate
 
 # Class of Service template for voicemail enabled users
 CosDisplayName  = Voice Mail User COS
-
-# Custom HTML Missed Call Notification Templated ID
-NotificationTemplateID = 2c019f05-06b0-4e47-b0ff-617883fb8331
 '@


### PR DESCRIPTION
This pull request changes Set-CUCNotificationHTMLDevice from using a static notificationtemplateid to environment agnostic notificationtemplateids.
A new command is also pushed into master: Get-CUCNotificationTemplate